### PR TITLE
Add saving priority for tasks and colored checkboxes

### DIFF
--- a/ToDoListApp.xcodeproj/project.pbxproj
+++ b/ToDoListApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		F4690F722B31C97C00317695 /* PriorityEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4690F712B31C97C00317695 /* PriorityEnum.swift */; };
 		F46C04682B23373C008C34CE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F46C04672B23373C008C34CE /* AppDelegate.swift */; };
 		F46C046A2B23373C008C34CE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F46C04692B23373C008C34CE /* SceneDelegate.swift */; };
 		F46C046C2B23373C008C34CE /* ToDoListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F46C046B2B23373C008C34CE /* ToDoListViewController.swift */; };
@@ -23,6 +24,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		F4690F712B31C97C00317695 /* PriorityEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriorityEnum.swift; sourceTree = "<group>"; };
 		F46C04642B23373B008C34CE /* ToDoListApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ToDoListApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F46C04672B23373C008C34CE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F46C04692B23373C008C34CE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -78,6 +80,7 @@
 				F4C0CEE52B2A11F000B1E63C /* ToDoListItemManager.swift */,
 				F4C0CEE12B29C3E300B1E63C /* ColorExtension.swift */,
 				F4DC9C602B2F7432004E1EA9 /* CheckboxTableViewCell.swift */,
+				F4690F712B31C97C00317695 /* PriorityEnum.swift */,
 				F46C046D2B23373C008C34CE /* Main.storyboard */,
 				F46C04732B23373D008C34CE /* Assets.xcassets */,
 				F46C04752B23373D008C34CE /* LaunchScreen.storyboard */,
@@ -171,6 +174,7 @@
 				F46C04882B238161008C34CE /* ModalViewController.swift in Sources */,
 				F46C04682B23373C008C34CE /* AppDelegate.swift in Sources */,
 				F4C0CEE62B2A11F000B1E63C /* ToDoListItemManager.swift in Sources */,
+				F4690F722B31C97C00317695 /* PriorityEnum.swift in Sources */,
 				F4C0CEE22B29C3E300B1E63C /* ColorExtension.swift in Sources */,
 				F46C046A2B23373C008C34CE /* SceneDelegate.swift in Sources */,
 				F4DC9C612B2F7432004E1EA9 /* CheckboxTableViewCell.swift in Sources */,

--- a/ToDoListApp/ModalViewController.swift
+++ b/ToDoListApp/ModalViewController.swift
@@ -202,11 +202,11 @@ class ModalViewController: UIViewController {
             print("Update Task")
             guard let taskItemToUpdate = taskItemToUpdate else { return }
             guard let newTaskName = taskTextField.text, !newTaskName.isEmpty else { return }
-            ToDoListItemManager.updateItem(item: taskItemToUpdate, newName: newTaskName, newPriority: "")
+            ToDoListItemManager.updateItem(item: taskItemToUpdate, newName: newTaskName, newPriority: definePriority())
         } else {
             print("Create Task")
             guard let textField = taskTextField.text, !textField.isEmpty else { return }
-            ToDoListItemManager.createItem(name: textField, priority: "")
+            ToDoListItemManager.createItem(name: textField, priority: definePriority())
         }
         self.dismiss(animated: true, completion: nil)
     }
@@ -214,6 +214,20 @@ class ModalViewController: UIViewController {
     @objc private func didTapCancelButton() {
         print("Cancel")
         self.dismiss(animated: true, completion: nil)
+    }
+    
+    private func definePriority() -> String {
+        let selectedPriority = prioritySegmentedControl.selectedSegmentIndex
+        switch selectedPriority {
+        case 0:
+            return TaskPriority.low.rawValue
+        case 1:
+            return TaskPriority.medium.rawValue
+        case 2:
+            return TaskPriority.high.rawValue
+        default:
+            return ""
+        }
     }
     
 }

--- a/ToDoListApp/PriorityEnum.swift
+++ b/ToDoListApp/PriorityEnum.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum TaskPriority: String {
+    case low = "Low"
+    case medium = "Medium"
+    case high = "High"
+}

--- a/ToDoListApp/ToDoListItemManager.swift
+++ b/ToDoListApp/ToDoListItemManager.swift
@@ -45,6 +45,7 @@ class ToDoListItemManager {
     
     static func updateItem(item: ToDoListItem, newName: String, newPriority: String) {
         item.taskName = newName
+        item.priority = newPriority
         do {
             try context.save()
             onListChangeDelegate?()

--- a/ToDoListApp/ToDoListViewController.swift
+++ b/ToDoListApp/ToDoListViewController.swift
@@ -77,6 +77,18 @@ class ToDoListViewController: UIViewController, UITableViewDelegate, UITableView
         cell.backgroundColor = .clear
         cell.label.text = task.taskName
         cell.label.textColor = .white
+        
+        switch task.priority {
+        case TaskPriority.low.rawValue:
+            cell.checkboxButton.tintColor = .greenLowPriorityColor
+        case TaskPriority.medium.rawValue:
+            cell.checkboxButton.tintColor = .yellowMediumPriorityColor
+        case TaskPriority.high.rawValue:
+            cell.checkboxButton.tintColor = .redHighPriorityColor
+        default:
+            cell.checkboxButton.tintColor = .white
+        }
+        
         cell.checkboxButton.isSelected = false
         return cell
     }


### PR DESCRIPTION
Add saving priority for tasks, so that user can see colored checkboxes depending on what priority user chose for the task - red color for high priority, yellow for medium and green for low task priority.